### PR TITLE
Merge default env, with any env settings provided, when creating process

### DIFF
--- a/service/exec.go
+++ b/service/exec.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"github.com/golang/protobuf/proto"
 	"github.com/taskcluster/runlib/contester_proto"
 	"github.com/taskcluster/runlib/subprocess"
-	"github.com/golang/protobuf/proto"
 )
 
 func fillEnv(src *contester_proto.LocalEnvironment) *[]string {

--- a/service/service.go
+++ b/service/service.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/golang/protobuf/proto"
 	"github.com/taskcluster/runlib/contester_proto"
 	"github.com/taskcluster/runlib/platform"
 	"github.com/taskcluster/runlib/storage"
 	"github.com/taskcluster/runlib/subprocess"
-	"github.com/golang/protobuf/proto"
 	"gopkg.in/gcfg.v1"
 )
 

--- a/subprocess/subprocess_windows.go
+++ b/subprocess/subprocess_windows.go
@@ -154,7 +154,10 @@ func (sub *Subprocess) CreateFrozen() (*SubprocessData, error) {
 
 	applicationName := win32.StringPtrToUTF16Ptr(sub.Cmd.ApplicationName)
 	commandLine := win32.StringPtrToUTF16Ptr(sub.Cmd.CommandLine)
-	environment := win32.ListToEnvironmentBlock(sub.Environment)
+	environment, e := win32.CreateEnvironment(sub.Environment, sub.Login.HUser)
+	if e != nil {
+		return nil, e
+	}
 	currentDirectory := win32.StringPtrToUTF16Ptr(sub.CurrentDirectory)
 
 	var syscallName string

--- a/tools/stat.go
+++ b/tools/stat.go
@@ -3,8 +3,8 @@ package tools
 import (
 	"os"
 
-	"github.com/taskcluster/runlib/contester_proto"
 	"github.com/golang/protobuf/proto"
+	"github.com/taskcluster/runlib/contester_proto"
 )
 
 func StatFile(name string, hash_it bool) (*contester_proto.FileStat, error) {

--- a/win32/extra_windows.go
+++ b/win32/extra_windows.go
@@ -119,5 +119,5 @@ func CreateEnvironment(env *[]string, hUser syscall.Handle) (envBlock *uint16, e
 		}
 		fmt.Printf("%v: %X\n", len, *x)
 	}
-	return nil, nil
+	return ListToEnvironmentBlock(env), nil
 }

--- a/win32/extra_windows.go
+++ b/win32/extra_windows.go
@@ -1,14 +1,18 @@
 package win32
 
 import (
+	"fmt"
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 var (
-	procCloseDesktop     = user32.NewProc("CloseDesktop")
-	procSwitchDesktop    = user32.NewProc("SwitchDesktop")
-	procSetPriorityClass = kernel32.NewProc("SetPriorityClass")
+	procCloseDesktop            = user32.NewProc("CloseDesktop")
+	procSwitchDesktop           = user32.NewProc("SwitchDesktop")
+	procSetPriorityClass        = kernel32.NewProc("SetPriorityClass")
+	procCreateEnvironmentBlock  = userenv.NewProc("CreateEnvironmentBlock")
+	procDestroyEnvironmentBlock = userenv.NewProc("DestroyEnvironmentBlock")
 )
 
 const (
@@ -62,4 +66,58 @@ func SetPriorityClass(
 		err = os.NewSyscallError("SetPriorityClass", e1)
 	}
 	return
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/bb762270(v=vs.85).aspx
+func CreateEnvironmentBlock(
+	lpEnvironment *uintptr, // LPVOID
+	hToken syscall.Handle, // HANDLE
+	bInherit bool, // BOOL
+) (err error) {
+	inherit := uint32(0)
+	if bInherit {
+		inherit = 1
+	}
+	r1, _, e1 := procCreateEnvironmentBlock.Call(
+		uintptr(unsafe.Pointer(&lpEnvironment)),
+		uintptr(hToken),
+		uintptr(inherit),
+	)
+	if r1 == 0 {
+		err = os.NewSyscallError("CreateEnvironmentBlock", e1)
+	}
+	return
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/bb762274(v=vs.85).aspx
+func DestroyEnvironmentBlock(
+	lpEnvironment *uintptr, // LPVOID
+) (err error) {
+	r1, _, e1 := procDestroyEnvironmentBlock.Call(
+		uintptr(unsafe.Pointer(&lpEnvironment)),
+	)
+	if r1 == 0 {
+		err = os.NewSyscallError("DestroyEnvironmentBlock", e1)
+	}
+	return
+}
+
+// CreateEnvironment returns an environment block, suitable for use with the
+// CreateProcessAsUser system call. The default environment variables of hUser
+// are overlayed with values in env.
+func CreateEnvironment(env *[]string, hUser syscall.Handle) (envBlock *uint16, err error) {
+	var logonEnv uintptr
+	err = CreateEnvironmentBlock(&logonEnv, hUser, false)
+	if err != nil {
+		return
+	}
+	defer DestroyEnvironmentBlock(&logonEnv)
+	for len := 0; len < 10000; len++ {
+		x := (*uint32)(unsafe.Pointer(logonEnv + uintptr(len)))
+		if *x == 0 {
+			break
+		}
+		fmt.Printf("%v: %X\n", len, *x)
+	}
+	return nil, nil
 }

--- a/win32/win32acl_windows.go
+++ b/win32/win32acl_windows.go
@@ -5,8 +5,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/taskcluster/runlib/tools"
 	"runtime"
+
+	"github.com/taskcluster/runlib/tools"
 )
 
 var (


### PR DESCRIPTION
This adds a `CreateEnvironmentBlock` call to get default env for a user, before applying additional env settings...